### PR TITLE
set_pos/resultにrequest_idを追加

### DIFF
--- a/README_types.md
+++ b/README_types.md
@@ -335,6 +335,7 @@ TriorbRunSetting setting    # 走行設定
 ### triorb_drive_interface/msg/TriorbSetPos3.msg
 ```bash
 #==目標位置・姿勢指示による移動==
+uint32 request_id           # Unique request ID copied to TriorbRunResult (0: downstream assigns)
 TriorbRunPos3 pos           # Goal position
 TriorbRunSetting setting    # Configure of navigation
 ```
@@ -351,6 +352,7 @@ float32 deg     # [deg]
 ```bash
 #==自律移動結果==
 std_msgs/Header header      # Header
+uint32 request_id           # Request ID copied from TriorbSetPos3
 bool success                # Moving result (true: Compleat, false: Feild)
 uint8 info                  # Moving result info ( substitution NAVIGATE_RESULT )
 TriorbPos3 position         # Last robot position
@@ -359,6 +361,7 @@ TriorbPos3 position         # Last robot position
 ### triorb_drive_interface/msg/TriorbRunResult.msg
 ```bash
 #==自律移動結果==
+uint32 request_id           # Request ID copied from TriorbSetPos3
 bool success                # Moving result (true: Compleat, false: Feild)
 uint8 info                  # Moving result info ( substitution NAVIGATE_RESULT )
 TriorbPos3 position         # Last robot position
@@ -726,4 +729,3 @@ std_msgs/Header header                              # Header
 string master                                       # Master
 triorb_collaboration_interface/ParentBind[] robots  # Robot informations
 ```
-

--- a/triorb_drive_interface/README.md
+++ b/triorb_drive_interface/README.md
@@ -74,6 +74,7 @@ TriorbPos3 position
 
 ### triorb_drive_interface/msg/TriorbRunResult
 ```bash
+uint32 request_id
 bool success
 TriorbPos3 position
 ```
@@ -94,6 +95,7 @@ TriorbVel3 velocity
 
 ### triorb_drive_interface/msg/TriorbSetPos3
 ```bash
+uint32 request_id
 TriorbRunPos3 pos
 TriorbRunSetting setting
 ```

--- a/triorb_drive_interface/msg/TriorbRunResult.msg
+++ b/triorb_drive_interface/msg/TriorbRunResult.msg
@@ -15,6 +15,7 @@
 #**
 
 #==自律移動結果==
+uint32 request_id           # Request ID copied from TriorbSetPos3
 bool success                # Moving result (true: Compleat, false: Feild)
 uint8 info                  # Moving result info ( substitution NAVIGATE_RESULT )
 TriorbPos3 position         # Last robot position

--- a/triorb_drive_interface/msg/TriorbRunResultStamped.msg
+++ b/triorb_drive_interface/msg/TriorbRunResultStamped.msg
@@ -16,6 +16,7 @@
 
 #==自律移動結果==
 std_msgs/Header header      # Header
+uint32 request_id           # Request ID copied from TriorbSetPos3
 bool success                # Moving result (true: Compleat, false: Feild)
 uint8 info                  # Moving result info ( substitution NAVIGATE_RESULT )
 TriorbPos3 position         # Last robot position

--- a/triorb_drive_interface/msg/TriorbSetPos3.msg
+++ b/triorb_drive_interface/msg/TriorbSetPos3.msg
@@ -15,6 +15,6 @@
 #**
 
 #==目標位置・姿勢指示による移動==
+uint32 request_id           # Unique request ID copied to TriorbRunResult (0: downstream assigns)
 TriorbRunPos3 pos           # Goal position
 TriorbRunSetting setting    # Configure of navigation
-


### PR DESCRIPTION
## 目的

`TriorbSetPos3` と `TriorbRunResult` / `TriorbRunResultStamped` を一意に対応付け、古い移動結果を上位側で安全に無視できるようにします。

## 実装内容

- `TriorbSetPos3.msg` に `uint32 request_id` を追加
- `TriorbRunResult.msg` に `uint32 request_id` を追加
- `TriorbRunResultStamped.msg` に `uint32 request_id` を追加
- `TriorbSetPos3.request_id == 0` は未指定として扱い、後段のnavigation側で非0のIDを採番する前提をコメントに明記
- README / 型一覧を更新

## テスト

- 親リポジトリ側で `triorb_drive_interface` と依存ROSパッケージをビルドし、msg生成と依存ビルドが通ることを確認しました。
