### PR TITLE
SlamStatusに休止状態bit定数を追加

### DIFF
--- a/README_types.md
+++ b/README_types.md
@@ -168,16 +168,30 @@ uint8 state      # mapping now, fix map... etc
 uint8 error      # not working, map load failed... etc
 
 #---slam operation status (bit flag)---
-# 0b00000001: mapping mode(0), fix map(1)
-# 0b00000010: lost(0), localize(1)
-# 0b00000100: processing save map 
-# 0b00001000: processing load map
- 
+# 地図更新モード(0)ではなく固定地図モード(1)で動作している。
+uint8 STATE_MAP_FIXED=1
+# 自己位置推定が成立している。
+uint8 STATE_LOCALIZED=2
+# 地図保存処理中。
+uint8 STATE_SAVING_MAP=4
+# 地図読込処理中。
+uint8 STATE_LOADING_MAP=8
+# ユーザー操作などでSLAM本体を意図的に休止している。
+uint8 STATE_PAUSED=16
+# 地図ファイルの読込が完了しており、自己位置推定に使える地図名が確定している。
+uint8 STATE_MAP_LOADED=32
+# 地図読込完了後、自己位置推定が未成立または途切れている。
+uint8 STATE_LOST=64
+
 #---error state (bit flag)---
-# 0b00000001: slam is not working
-# 0b00000010: Never detected a known landmark
-# 0b00000100: save map failed
-# 0b00001000: load map failed (cannot find map)
+# SLAM本体が意図せず起動していない。
+uint8 ERROR_NOT_WORKING=1
+# 現在の起動または地図読込後に、まだ一度も自己位置推定が成立していない。
+uint8 ERROR_NEVER_LOCALIZED=2
+# 地図保存に失敗した。
+uint8 ERROR_MAP_SAVE_FAILED=4
+# 地図読込に失敗した。
+uint8 ERROR_MAP_LOAD_FAILED=8
 ```
 
 ### triorb_slam_interface/msg/PointArrayStamped.msg

--- a/triorb_slam_interface/msg/SlamStatus.msg
+++ b/triorb_slam_interface/msg/SlamStatus.msg
@@ -20,13 +20,27 @@ uint8 state      # mapping now, fix map... etc
 uint8 error      # not working, map load failed... etc
 
 #---slam operation status (bit flag)---
-# 0b00000001: mapping mode(0), fix map(1)
-# 0b00000010: lost(0), localize(1)
-# 0b00000100: processing save map 
-# 0b00001000: processing load map
- 
+# 地図更新モード(0)ではなく固定地図モード(1)で動作している。
+uint8 STATE_MAP_FIXED=1
+# 自己位置推定が成立している。
+uint8 STATE_LOCALIZED=2
+# 地図保存処理中。
+uint8 STATE_SAVING_MAP=4
+# 地図読込処理中。
+uint8 STATE_LOADING_MAP=8
+# ユーザー操作などでSLAM本体を意図的に休止している。
+uint8 STATE_PAUSED=16
+# 地図ファイルの読込が完了しており、自己位置推定に使える地図名が確定している。
+uint8 STATE_MAP_LOADED=32
+# 地図読込完了後、自己位置推定が未成立または途切れている。
+uint8 STATE_LOST=64
+
 #---error state (bit flag)---
-# 0b00000001: slam is not working
-# 0b00000010: Never detected a known landmark
-# 0b00000100: save map failed
-# 0b00001000: load map failed (cannot find map)
+# SLAM本体が意図せず起動していない。
+uint8 ERROR_NOT_WORKING=1
+# 現在の起動または地図読込後に、まだ一度も自己位置推定が成立していない。
+uint8 ERROR_NEVER_LOCALIZED=2
+# 地図保存に失敗した。
+uint8 ERROR_MAP_SAVE_FAILED=4
+# 地図読込に失敗した。
+uint8 ERROR_MAP_LOAD_FAILED=8


### PR DESCRIPTION
## 目的
TagSLAM/VSLAMで共通利用する `SlamStatus.msg` に、状態/エラーを判定するためのbit定数を追加します。

## 実装内容
- `SlamStatus.msg` に汎用的なstate/error bit定数を追加
- `STATE_PAUSED` を追加し、意図的なSLAM休止を異常停止と区別可能にする
- `STATE_MAP_LOADED` と `STATE_LOST` を追加し、地図更新モードかつ地図読込済みかつLOST中でも `state=0` にならないようにする
- TagSLAM固有に読める定数名を避けるため、以下の汎用名へ整理
  - `STATE_MAP_FIXED`
  - `STATE_LOCALIZED`
  - `STATE_SAVING_MAP`
  - `STATE_LOADING_MAP`
  - `STATE_PAUSED`
  - `STATE_MAP_LOADED`
  - `STATE_LOST`
  - `ERROR_NOT_WORKING`
  - `ERROR_NEVER_LOCALIZED`
  - `ERROR_MAP_SAVE_FAILED`
  - `ERROR_MAP_LOAD_FAILED`
- `README_types.md` のSlamStatus説明を更新

## テスト
- vslamコンテナ内で `triorb_slam_interface` の一時build成功
- 生成後の各定数値をPython importで確認
  - `STATE_MAP_FIXED=1`
  - `STATE_LOCALIZED=2`
  - `STATE_SAVING_MAP=4`
  - `STATE_LOADING_MAP=8`
  - `STATE_PAUSED=16`
  - `STATE_MAP_LOADED=32`
  - `STATE_LOST=64`
  - `ERROR_NOT_WORKING=1`
  - `ERROR_NEVER_LOCALIZED=2`
  - `ERROR_MAP_SAVE_FAILED=4`
  - `ERROR_MAP_LOAD_FAILED=8`

## 備考
- 既存の `map_name/state/error` フィールドは変更していません。
- #20 の `feature/positioning-timeout-mode-srv` に対する積み上げPRです。
