### PR TITLE
Add TF source selection to localization settings

### DIFF
--- a/README_types.md
+++ b/README_types.md
@@ -455,10 +455,10 @@ float32 vw      # Rotation velocity vector around the Z axis [rad/s]
 ```bash
 #==自律移動の位置決め設定==
 # TF source used for localization
-uint8 TF_SOURCE_UNSPECIFIED=0
-uint8 TF_SOURCE_VSLAM=1
-uint8 TF_SOURCE_TAGSLAM=2
-uint8 TF_SOURCE_COLLAB=3
+uint32 TF_SOURCE_UNSPECIFIED=0
+uint32 TF_SOURCE_VSLAM=1
+uint32 TF_SOURCE_TAGSLAM=2
+uint32 TF_SOURCE_COLLAB=3
 
 float32 tx                  # Target error in X-axis direction [±m]
 float32 ty                  # Target error in Y-axis direction [±m].
@@ -467,7 +467,7 @@ uint8 force                 # Target force level
 uint8 gain_no               # Number of gain type (not set:0, basic:1)
 uint32 timeout_ms           # Timeout (in ms) for the operation to complete (set:0, disable)
 uint8[] disable_camera_idx  # Camera Index to be excluded from robot pose estimation
-uint8 tf_source             # TF source used for localization 
+uint32 tf_source             # TF source used for localization 
 ```
 
 ### triorb_drive_interface/msg/TriorbPos3Stamped.msg

--- a/README_types.md
+++ b/README_types.md
@@ -454,6 +454,12 @@ float32 vw      # Rotation velocity vector around the Z axis [rad/s]
 ### triorb_drive_interface/msg/TriorbRunSetting.msg
 ```bash
 #==自律移動の位置決め設定==
+# TF source used for localization
+uint8 TF_SOURCE_UNSPECIFIED=0
+uint8 TF_SOURCE_VSLAM=1
+uint8 TF_SOURCE_TAGSLAM=2
+uint8 TF_SOURCE_COLLAB=3
+
 float32 tx                  # Target error in X-axis direction [±m]
 float32 ty                  # Target error in Y-axis direction [±m].
 float32 tr                  # Target error in rotation [±deg].
@@ -461,6 +467,7 @@ uint8 force                 # Target force level
 uint8 gain_no               # Number of gain type (not set:0, basic:1)
 uint32 timeout_ms           # Timeout (in ms) for the operation to complete (set:0, disable)
 uint8[] disable_camera_idx  # Camera Index to be excluded from robot pose estimation
+uint8 tf_source             # TF source used for localization 
 ```
 
 ### triorb_drive_interface/msg/TriorbPos3Stamped.msg

--- a/triorb_drive_interface/msg/TriorbRunSetting.msg
+++ b/triorb_drive_interface/msg/TriorbRunSetting.msg
@@ -17,10 +17,10 @@
 #==自律移動の位置決め設定==
 
 # TF source used for localization
-uint8 TF_SOURCE_UNSPECIFIED=0
-uint8 TF_SOURCE_VSLAM=1
-uint8 TF_SOURCE_TAGSLAM=2
-uint8 TF_SOURCE_COLLAB=3
+uint32 TF_SOURCE_UNSPECIFIED=0
+uint32 TF_SOURCE_VSLAM=1
+uint32 TF_SOURCE_TAGSLAM=2
+uint32 TF_SOURCE_COLLAB=3
 
 float32 tx                  # Target error in X-axis direction [±m]
 float32 ty                  # Target error in Y-axis direction [±m].
@@ -29,4 +29,4 @@ uint8 force                 # Target force level
 uint8 gain_no               # Number of gain type (not set:0, basic:1)
 uint32 timeout_ms           # Timeout (in ms) for the operation to complete (set:0, disable)
 uint8[] disable_camera_idx  # Camera Index to be excluded from robot pose estimation
-uint8 tf_source             # TF source used for localization
+uint32 tf_source            # TF source used for localization

--- a/triorb_drive_interface/msg/TriorbRunSetting.msg
+++ b/triorb_drive_interface/msg/TriorbRunSetting.msg
@@ -15,6 +15,13 @@
 #**
 
 #==自律移動の位置決め設定==
+
+# TF source used for localization
+uint8 TF_SOURCE_UNSPECIFIED=0
+uint8 TF_SOURCE_VSLAM=1
+uint8 TF_SOURCE_TAGSLAM=2
+uint8 TF_SOURCE_COLLAB=3
+
 float32 tx                  # Target error in X-axis direction [±m]
 float32 ty                  # Target error in Y-axis direction [±m].
 float32 tr                  # Target error in rotation [±deg].
@@ -22,3 +29,4 @@ uint8 force                 # Target force level
 uint8 gain_no               # Number of gain type (not set:0, basic:1)
 uint32 timeout_ms           # Timeout (in ms) for the operation to complete (set:0, disable)
 uint8[] disable_camera_idx  # Camera Index to be excluded from robot pose estimation
+uint8 tf_source             # TF source used for localization


### PR DESCRIPTION
## 概要

自律移動の位置決め設定メッセージに、使用する TF ソースを指定するための `tf_source` を追加しました。

これにより、VSLAM / TagSLAM / Collab で set_pose 用の topic を分けず、同じ topic / msg 上で使用する TF ソースを切り替えられるようにしました。

## 変更内容

* 位置決め設定用の ROS 2 msg に `tf_source` を追加
* `tf_source` の値を判別するための定数を追加

  * `TF_SOURCE_UNSPECIFIED=0`
  * `TF_SOURCE_VSLAM=1`
  * `TF_SOURCE_TAGSLAM=2`
  * `TF_SOURCE_COLLAB=3`

## 目的

従来は、set_pose 実行時に使用する TF ソースを明示的に指定する項目がありませんでした。

今回 `tf_source` を追加することで、VSLAM / TagSLAM / Collab のどの TF を使用するかを msg 上で指定できるようにしました。

これにより、TF 種別ごとに set_pose 用の topic を増やす必要がなくなり、同じ topic と同じ msg で位置決め処理を共通化できます。

## メリット

* VSLAM / TagSLAM / Collab ごとに set_pose topic を分けなくてよい
* publisher / subscriber 側のインターフェースを共通化できる
* 上位制御側やフロントエンド側からも、同じ topic に対して `tf_source` を指定するだけで切り替えられる
* 数値を直接扱わず定数で判定できるため、実装の可読性が向上する
* 将来的に TF ソースが増えた場合も、定数追加で拡張しやすい

## 確認項目

* msg 定義に `tf_source` が追加されていること
* `TF_SOURCE_VSLAM` / `TF_SOURCE_TAGSLAM` / `TF_SOURCE_COLLAB` で TF ソースを判別できること
* 既存フィールドへの影響がないこと
* msg 生成後にビルドが通ること
